### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,192 @@
+# Changelog
+
+All notable changes to `likeminds-chat-ios-data`, generated from its GitHub Releases.
+
+Full release history: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases
+
+---
+
+## [1.9.1] - 2025-06-19
+
+### What's Changed
+* Added Func to get unread-msg-count by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/50
+* Release/v1.9.1 by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/51
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.9.0...1.9.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.9.1)
+
+## [1.9.0] - 2025-05-29
+
+### What's Changed
+* [LM-13378] Reply Privately by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/45
+* [LM-13551] Added method for get existing dm chatroom by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/43
+* Release/v1.9.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/49
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.8.1...1.9.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.9.0)
+
+## [1.8.1] - 2025-05-06
+
+### What's Changed
+* [LM-13715] Added support of URL Components by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/47
+* Release/v1.8.1 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/48
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.8.0...1.8.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.8.1)
+
+## [1.8.0] - 2025-04-26
+
+### What's Changed
+* LM-13270 AIChat Bot Methods & Models by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/44
+* Release/v1.8.0 by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/46
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.7.1...1.8.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.8.0)
+
+## [1.7.1] - 2025-04-07
+
+### What's Changed
+* [LM-13394] Added Support filter state  by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/40
+* Release/v1.7.1 by @ArpitVerma807 in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/41
+* Release/v1.7.1 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/42
+
+### New Contributors
+* @ArpitVerma807 made their first contribution in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/40
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.7.0...1.7.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.7.1)
+
+## [1.7.0] - 2025-04-02
+
+### What's Changed
+* [LM-12405] Added network interceptor for retry mechanism by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/38
+* Release/v1.7.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/39
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.6.0...1.7.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.7.0)
+
+## [1.6.0] - 2025-02-13
+
+### What's Changed
+* [LM-12288] Added Search in a Chatroom Flow by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/31
+* [LM-12560] Added secret chatroom invite methods by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/34
+* [LM-13189] Added logout function by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/35
+* [LM-13452] Fixed peer testing issues by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/37
+* Release/v1.6.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/36
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.5.3...1.6.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.6.0)
+
+## [1.5.3] - 2025-01-15
+
+### What's Changed
+* [LM-13288] Fixed migration issue in schema version 5 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/32
+* Release/v1.5.3 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/33
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.5.2...1.5.3
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.5.3)
+
+## [1.5.2] - 2024-12-11
+
+### What's Changed
+* [LM-13227] added likemindschatdata podspec by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/29
+* Release/v1.5.2 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/30
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.5.1...1.5.2
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.5.2)
+
+## [1.5.1] - 2024-12-11
+
+### What's Changed
+* LM-13138 Refactoring of methods and classes by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/27
+* Release/v1.5.1 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/28
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.5.0...1.5.2
+
+### What's Changed
+* LM-13138 Refactoring of methods and classes by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/27
+* Release/v1.5.1 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/28
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.5.0...1.5.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.5.1)
+
+## [1.5.0] - 2024-11-26
+
+### What's Changed
+* [LM-12386] Added custom widget support in conversation by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/24
+* Product Signoff v1.5.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/26
+* Release/v1.5.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/25
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.4.0...1.5.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.5.0)
+
+## [1.4.0] - 2024-11-05
+
+### What's Changed
+* [LM-12648] Added AI chatbot by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/21
+* Version/v1.4.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/23
+* Release/v1.4.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/22
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.3.1...1.4.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.4.0)
+
+## [1.3.1] - 2024-10-16
+
+### What's Changed
+* Release v1.3.0 by @pushpendralike in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/17
+* [LM-12727] Added filter conversation states methods and minor refactoring keys by @pushpendralike in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/19
+* Release v1.3.1 by @pushpendralike in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/20
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/1.2.0...1.3.1
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.3.1)
+
+## [1.2.0] - 2024-07-15
+
+### What's Changed
+* [LM-10925] Added api key security  by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/13
+* Version/v1.2.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/15
+* Release/v1.2.0 by @TyagiLikeMinds in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/14
+
+### New Contributors
+* @TyagiLikeMinds made their first contribution in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/13
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/compare/v1.1.0...1.2.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/1.2.0)
+
+## [1.1.0] - 2024-07-15
+
+### What's Changed
+* Release v1.1.0 by @pushpendralike in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/8
+* Release v1.1.0 by @pushpendralike in https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/pull/12
+
+
+**Full Changelog**: https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/commits/v1.1.0
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-ios-data/releases/tag/v1.1.0)


### PR DESCRIPTION
Generated from this repo's GitHub Releases: every published version with its date and release notes, newest first.

Anyone upgrading a published package currently has to read git history or click through the Releases page to find out what changed. This puts it in the repo where people look for it.

Nothing is invented - each entry is the release body as written, with headings demoted one level so they nest under the version. Each entry links back to its release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)